### PR TITLE
metal_device example update for "Group devices by facility"

### DIFF
--- a/docs/tables/metal_device.md
+++ b/docs/tables/metal_device.md
@@ -52,7 +52,7 @@ group by
   f.code,
   f.name
 order by
-  count desc
+  num_devices desc
 ```
 
 ### List devices with OS information


### PR DESCRIPTION
Change this to avoid the error `Error: column "count" does not exist` in the example "Group devices by facility"\

Fixes #4 